### PR TITLE
Add Threshold: First Fleet — playable RTS game of the Battle of Thres…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the Ascent Universe companion website.
 
 ---
 
+## Session 13 (2026-06-10) — Threshold: First Fleet RTS Game
+
+### New Game
+- **Threshold: First Fleet** (`threshold-game.html`) — Fully playable real-time strategy game recreating the Battle of Threshold (2909 CE) from the Eszel prologue. Single self-contained page, canvas 2D, no dependencies.
+  - **Forces**: Player commands all ten Union destroyer battlegroups (Isidore, Jayapal, Acheron, Kepler, Novgorod, Tenacity + four more), each screened by nine unmanned corvettes — 100 ships, matching canon. Enemy: three Incisors and one Annihilator, AI-controlled.
+  - **Canon mechanics**: X-ray lasers intercept torpedoes at range (long volleys melt "like snow"; massed close-range volleys saturate the defence); invisible spinal duster fire kills ships "with no apparent cause" until the player analyses sensor logs (the Hansun moment) and unlocks submillimetre radar; Striver malware fires an uncommanded opening volley; weapons hold until Arco engages.
+  - **Signature tactics**: Play dead (drives cold, enemy ignores dark hulks beyond ~350 km) and the 30G suicide charge — irreversible, kills the crew, empties every tube point-blank and rams. Launched from cold at close range it strikes with total surprise: the Isidore gambit.
+  - **Enemy AI**: Incisors hold standoff outside railgun range, dodge incoming rounds, execute high-speed attack runs through the formation, and break off when wounded. Annihilator launches antimatter smart-missile swarms that detonate beyond PDC range. Arco withdraws through the interstice when the fleet is broken.
+  - **Aftermath scoring** graded against the historical record: 97 of 100 ships lost, one Incisor destroyed, sole survivor Ensign Hansun. Outcome tiers from ANNIHILATION to IMPOSSIBLE VICTORY.
+  - Balance verified by headless simulation: passive fleets are destroyed with zero kills; naive aggression matches history (1 kill); coordinated close volleys and cold charges are decisively rewarded.
+- Added to nav (`FIRST FLEET`), simulations hub (new PLAYABLE section), home page card grid, and README.
+
+---
+
 ## Session 12 (2026-03-07) — Infrastructure, New Content & Story Readers
 
 Major session: infrastructure improvements, new interactive content, and nine new story readers.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Toggle using the theme button in the nav bar.
 | **Drafts** | `drafts.html` | Draft browser for second-draft manuscripts |
 | **MSD (Annihilator)** | `msd.html` | Interactive 3D MSD for the Annihilator-class IP Assault Vehicle |
 | **MSD (D-Sphere)** | `msd-dsphere.html` | Interactive 3D MSD for the Ultimate Height-class Defence Sphere |
+| **Threshold: First Fleet** | `threshold-game.html` | Playable real-time strategy game — command Union's First Fleet at the Battle of Threshold (2909 CE) |
 | **Battle** | `battle.html` | Phase-by-phase animated tactical reconstruction of the Battle of the Interstice |
 | **Science** | `science.html` | Science Compendium — real physics behind the fictional technology |
 | **Timeline** | `timeline.html` | Interactive chronology from Deep Antiquity to the Apathy War |

--- a/index.html
+++ b/index.html
@@ -238,10 +238,17 @@ body { overflow-y: auto; }
         <div class="section-rule"></div>
       </div>
 
+      <a href="threshold-game.html" class="nav-card" style="grid-column: 1 / -1;">
+        <span class="card-icon" style="color:var(--accent2)">&#9876;</span>
+        <div class="card-title">THRESHOLD: FIRST FLEET &mdash; PLAYABLE RTS</div>
+        <div class="card-desc">Command Union's First Fleet at the Battle of Threshold, 2909 CE. Ten destroyer battlegroups against four Arco warships. Real-time strategy in the browser &mdash; history records one kill. Beat it.</div>
+        <span class="card-arrow">&rarr;</span>
+      </a>
+
       <a href="simulations.html" class="nav-card" style="grid-column: 1 / -1;">
         <span class="card-icon" style="color:var(--accent2)">&#9670;</span>
         <div class="card-title">SIMULATIONS HUB</div>
-        <div class="card-desc">17 tactical reconstructions, weapon systems, combat simulators, and interactive environments. Battle of the Interstice, warseed activation, A-sphere combat, interstice transit, and more.</div>
+        <div class="card-desc">18 tactical reconstructions, weapon systems, combat simulators, games, and interactive environments. Battle of the Interstice, warseed activation, A-sphere combat, interstice transit, and more.</div>
         <span class="card-arrow">&rarr;</span>
       </a>
 

--- a/nav.js
+++ b/nav.js
@@ -40,6 +40,7 @@
     { href: 'utilitaria-escape.html', label: 'ESCAPE' },
     { href: 'bridge-tactical.html', label: 'BRIDGE' },
     { href: 'msd-dsphere.html', label: 'D-SPHERE' },
+    { href: 'threshold-game.html', label: 'FIRST FLEET' },
   ];
 
   const current = location.pathname.split('/').pop() || 'index.html';

--- a/simulations.html
+++ b/simulations.html
@@ -33,6 +33,19 @@ body { overflow-y: auto; }
   <div class="page-sub">TACTICAL RECONSTRUCTIONS &middot; INTERACTIVE MODELS &middot; COMBAT SYSTEMS</div>
 
   <div class="sim-section">
+    <div class="section-label">PLAYABLE</div>
+    <div class="section-rule"></div>
+    <div class="sim-grid">
+      <a href="threshold-game.html" class="sim-card" style="border-color: var(--accent2);">
+        <div class="card-era">2909 CE &mdash; THE BATTLE OF THRESHOLD</div>
+        <div class="card-title">THRESHOLD: FIRST FLEET</div>
+        <div class="card-desc">Real-time strategy. Command ten Union destroyer battlegroups against three Incisors and an Annihilator. Mass torpedo volleys against X-ray laser defences, survive invisible duster fire, play dead, and decide who makes the thirty-gee charge. History records one kill &mdash; beat it.</div>
+        <div class="card-type">RTS GAME &middot; PLAYABLE</div>
+      </a>
+    </div>
+  </div>
+
+  <div class="sim-section">
     <div class="section-label">TACTICAL RECONSTRUCTIONS</div>
     <div class="section-rule"></div>
     <div class="sim-grid">

--- a/threshold-game.html
+++ b/threshold-game.html
@@ -1,0 +1,1569 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<title>Threshold: First Fleet — Ascent Universe</title>
+<link rel="icon" href="favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="style.css">
+<style>
+body { overflow: hidden; }
+#game-root {
+  position: fixed; top: 40px; left: 0; right: 0; bottom: 28px;
+  background: #010508; overflow: hidden; cursor: crosshair;
+  font-family: var(--mono);
+}
+#gc { position: absolute; inset: 0; width: 100%; height: 100%; display: block; }
+
+/* ── HUD ─────────────────────────────────────────────────────────── */
+.hbtn {
+  background: rgba(0,20,30,0.85); border: 1px solid var(--border); color: var(--text-dim);
+  font-family: var(--mono); font-size: 9px; letter-spacing: 2px; padding: 5px 10px;
+  cursor: pointer; border-radius: 2px; transition: all 0.15s; white-space: nowrap;
+}
+.hbtn:hover { border-color: var(--accent); color: var(--accent); }
+.hbtn.armed { border-color: var(--accent); color: var(--accent); background: rgba(0,229,255,0.08); }
+.hbtn.danger { border-color: rgba(255,80,60,0.5); color: #ff6b50; }
+.hbtn.danger:hover, .hbtn.danger.armed { border-color: #ff5040; color: #ff5040; background: rgba(255,60,40,0.1); }
+.hbtn:disabled { opacity: 0.35; cursor: default; }
+
+#hud-top { position: absolute; top: 8px; left: 10px; display: flex; gap: 6px; align-items: center; z-index: 6; }
+#clock { font-size: 11px; color: var(--accent); letter-spacing: 2px; min-width: 64px; }
+#fleet-strip { position: absolute; top: 8px; left: 50%; transform: translateX(-50%); display: flex; gap: 3px; z-index: 6; }
+.fs-cell {
+  width: 22px; height: 22px; border: 1px solid var(--border); border-radius: 2px;
+  font-size: 9px; display: flex; align-items: center; justify-content: center;
+  color: var(--text-dim); background: rgba(0,15,22,0.8); cursor: pointer; position: relative;
+}
+.fs-cell .bar { position: absolute; bottom: 0; left: 0; height: 2px; background: var(--accent); }
+.fs-cell.sel { border-color: #fff; color: #fff; }
+.fs-cell.lost { opacity: 0.3; text-decoration: line-through; }
+
+#arco-strip { position: absolute; top: 36px; left: 50%; transform: translateX(-50%); display: flex; gap: 6px; z-index: 6; }
+.as-cell { font-size: 8px; letter-spacing: 1px; color: #ff7a5e; border: 1px solid rgba(255,107,53,0.35); padding: 2px 6px; border-radius: 2px; background: rgba(30,5,0,0.7); }
+.as-cell .bar { display: block; height: 2px; background: var(--accent2); margin-top: 2px; }
+.as-cell.lost { opacity: 0.3; text-decoration: line-through; }
+
+#event-log {
+  position: absolute; right: 10px; top: 64px; width: 320px; max-height: 50%;
+  z-index: 5; pointer-events: none; display: flex; flex-direction: column; gap: 3px;
+  overflow: hidden;
+}
+.ev { font-size: 9px; line-height: 1.5; letter-spacing: 0.5px; padding: 3px 8px; border-left: 2px solid var(--border);
+      background: rgba(0,10,16,0.75); color: var(--text-dim); animation: evIn 0.3s ease; }
+.ev .ts { color: rgba(120,160,170,0.5); margin-right: 6px; }
+.ev.warn { border-left-color: #ff5040; color: #ff8a70; }
+.ev.good { border-left-color: var(--accent); color: var(--accent); }
+.ev.quote { border-left-color: var(--accent2); color: #d8c8a8; font-style: italic; }
+@keyframes evIn { from { opacity: 0; transform: translateX(12px); } to { opacity: 1; transform: none; } }
+
+#hud-bottom {
+  position: absolute; left: 10px; bottom: 10px; right: 340px; z-index: 6;
+  display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap;
+}
+#sel-panel { display: flex; gap: 5px; flex-wrap: wrap; max-width: 60%; }
+.sel-card {
+  background: rgba(0,18,26,0.88); border: 1px solid var(--border); border-radius: 2px;
+  padding: 4px 8px; font-size: 8px; letter-spacing: 1px; color: var(--text-dim); min-width: 96px;
+}
+.sel-card .nm { color: var(--accent); font-size: 9px; margin-bottom: 2px; }
+.sel-card .hpb { height: 3px; background: rgba(255,255,255,0.08); margin: 3px 0; }
+.sel-card .hpb i { display: block; height: 100%; background: var(--accent); }
+.sel-card.cold .nm { color: #6a7e88; }
+#ability-bar { display: flex; gap: 6px; }
+
+#mode-banner {
+  position: absolute; top: 64px; left: 50%; transform: translateX(-50%); z-index: 7;
+  font-size: 10px; letter-spacing: 3px; color: var(--accent); padding: 6px 16px;
+  border: 1px solid var(--accent); background: rgba(0,20,30,0.9); display: none;
+}
+#mode-banner.danger { color: #ff5040; border-color: #ff5040; }
+
+#analyse-btn {
+  position: absolute; top: 110px; left: 50%; transform: translateX(-50%); z-index: 7;
+  display: none; animation: pulseBtn 1s ease-in-out infinite;
+}
+@keyframes pulseBtn { 0%,100% { box-shadow: 0 0 0 rgba(0,229,255,0); } 50% { box-shadow: 0 0 14px rgba(0,229,255,0.5); } }
+
+/* ── Overlays ────────────────────────────────────────────────────── */
+.overlay {
+  position: absolute; inset: 0; z-index: 20; display: flex; align-items: center; justify-content: center;
+  background: rgba(0,4,8,0.88); backdrop-filter: blur(3px);
+}
+.ov-panel {
+  max-width: 620px; width: calc(100% - 40px); max-height: 90%; overflow-y: auto;
+  border: 1px solid var(--border); background: rgba(2,12,18,0.97); padding: 28px 32px; border-radius: 3px;
+}
+.ov-panel h1 { font-size: 16px; letter-spacing: 6px; color: var(--accent); margin: 0 0 2px; font-weight: 400; }
+.ov-panel .sub { font-size: 9px; letter-spacing: 3px; color: var(--text-dim); margin-bottom: 18px; }
+.ov-panel p { font-size: 11px; line-height: 1.8; color: var(--text-dim); margin: 0 0 12px; }
+.ov-panel p b { color: var(--text); font-weight: 600; }
+.ov-panel .ctl { font-size: 9px; line-height: 2; color: var(--text-dim); letter-spacing: 1px; }
+.ov-panel .ctl b { color: var(--accent); display: inline-block; min-width: 110px; font-weight: 400; }
+.ov-panel .quote { border-left: 2px solid var(--accent2); padding-left: 12px; font-style: italic; color: #cbb894; font-size: 10px; }
+.ov-rule { height: 1px; background: var(--border); margin: 16px 0; }
+.big-btn {
+  display: block; width: 100%; margin-top: 18px; padding: 12px; text-align: center;
+  background: rgba(0,229,255,0.06); border: 1px solid var(--accent); color: var(--accent);
+  font-family: var(--mono); font-size: 11px; letter-spacing: 5px; cursor: pointer; transition: all 0.2s;
+}
+.big-btn:hover { background: rgba(0,229,255,0.15); }
+.stat-row { display: flex; justify-content: space-between; font-size: 10px; letter-spacing: 1px; color: var(--text-dim); padding: 4px 0; border-bottom: 1px dotted rgba(255,255,255,0.06); }
+.stat-row span:last-child { color: var(--text); }
+#aftermath-title { font-size: 18px; letter-spacing: 6px; margin-bottom: 4px; }
+
+@media (max-width: 800px) {
+  #event-log { width: 200px; top: 96px; }
+  #hud-bottom { right: 10px; }
+  #fleet-strip { top: 38px; }
+  #arco-strip { top: 66px; }
+  #analyse-btn { top: 140px; }
+}
+</style>
+</head>
+<body>
+<div id="game-root">
+  <canvas id="gc"></canvas>
+
+  <div id="hud-top">
+    <span id="clock">T+00:00</span>
+    <button class="hbtn" id="btn-pause">PAUSE</button>
+    <button class="hbtn" id="btn-speed">1&times;</button>
+    <button class="hbtn" id="btn-fit">FIT</button>
+    <button class="hbtn" id="btn-help">?</button>
+  </div>
+
+  <div id="fleet-strip"></div>
+  <div id="arco-strip"></div>
+  <div id="event-log"></div>
+  <div id="mode-banner"></div>
+  <button class="hbtn" id="analyse-btn">ANALYSE SENSOR LOGS [H]</button>
+
+  <div id="hud-bottom">
+    <div id="ability-bar">
+      <button class="hbtn" id="btn-all">ALL [A]</button>
+      <button class="hbtn" id="btn-volley">TORPEDO VOLLEY [T]</button>
+      <button class="hbtn" id="btn-dead">PLAY DEAD [D]</button>
+      <button class="hbtn danger" id="btn-charge">30G CHARGE [X]</button>
+    </div>
+    <div id="sel-panel"></div>
+  </div>
+
+  <div class="overlay" id="briefing">
+    <div class="ov-panel">
+      <h1>THRESHOLD: FIRST FLEET</h1>
+      <div class="sub">2909 CE &middot; TRAILING LAGRANGE POINT OF DELIVERANCE &middot; REAL-TIME TACTICAL COMMAND</div>
+      <p class="quote">In toil, absolution. In strife, salvation. In death, release.<br>&mdash; Human Purity Front creed</p>
+      <p>The hijacked freighter <b>Atbarah</b> has rammed through the interstice. Two hundred thousand are dead
+      on the far side. Striver malware is buried in the fleet network, and four Arco warships &mdash; three
+      <b>Incisors</b> and an <b>Annihilator</b> &mdash; have just emerged from the wormhole mouth.</p>
+      <p>You command Union&rsquo;s <b>First Fleet</b>: ten destroyer battlegroups, each screened by nine unmanned
+      corvettes. History records that 97 of your 100 ships were destroyed, and that the USV <b>Isidore</b>&rsquo;s
+      thirty-gee suicide charge claimed a single Incisor. That is the standard you are measured against.</p>
+      <div class="ov-rule"></div>
+      <div class="ctl">
+        <b>SELECT</b> click / drag-box &middot; number keys 1&ndash;0 &middot; A = all<br>
+        <b>MOVE / ATTACK</b> right-click space / right-click enemy<br>
+        <b>TORPEDO VOLLEY [T]</b> then click target &mdash; lasers intercept torps at range: <i>mass volleys, fire close</i><br>
+        <b>PLAY DEAD [D]</b> go cold &mdash; the enemy ignores dark hulks unless nearly aboard them<br>
+        <b>30G CHARGE [X]</b> irreversible ramming burn &mdash; the crew will not survive &mdash; launched from playing
+        dead at close range, it strikes without warning<br>
+        <b>CAMERA</b> wheel zoom &middot; middle-drag / arrows pan &middot; F = fit &middot; SPACE = pause
+      </div>
+      <div class="ov-rule"></div>
+      <p style="font-size:10px;">Their X-ray lasers kill torpedoes across tens of thousands of kilometres.
+      Their spinal dusters fire streams of hyperdiamond dust your radar cannot see &mdash; until someone in your
+      fleet works out what is killing you. Watch the log.</p>
+      <button class="big-btn" id="btn-start">ASSUME COMMAND</button>
+    </div>
+  </div>
+
+  <div class="overlay" id="aftermath" style="display:none">
+    <div class="ov-panel">
+      <h1 id="aftermath-title">ENGAGEMENT OVER</h1>
+      <div class="sub" id="aftermath-sub"></div>
+      <div id="aftermath-stats"></div>
+      <div class="ov-rule"></div>
+      <p class="quote" id="aftermath-quote"></p>
+      <p style="font-size:10px;" id="aftermath-canon"></p>
+      <button class="big-btn" id="btn-restart">RE-ENGAGE</button>
+    </div>
+  </div>
+
+  <div class="overlay" id="helpov" style="display:none">
+    <div class="ov-panel">
+      <h1>COMMAND REFERENCE</h1>
+      <div class="sub">FIRST FLEET TACTICAL DOCTRINE</div>
+      <div class="ctl">
+        <b>SELECT</b> left-click ship / drag selection box / shift-click to add<br>
+        <b>GROUPS 1&ndash;0</b> select battlegroup by number &middot; <b>A</b> select all<br>
+        <b>RIGHT-CLICK</b> move order &middot; on an enemy: attack order (railguns engage inside 1,000 km)<br>
+        <b>T</b> torpedo volley &mdash; 6 torps per group per volley, 36 carried. Enemy lasers intercept roughly
+        three torps per second per ship: saturate them with simultaneous volleys from multiple groups at close range.<br>
+        <b>D</b> play dead &mdash; drive and weapons cold. Enemies will not target a dark ship unless within ~350 km.
+        Any order other than a charge wakes the ship.<br>
+        <b>X</b> 30G charge &mdash; the drive is redlined far beyond crew tolerance. The ship homes on its target,
+        empties every remaining torpedo tube at point-blank range, and rams. Launched from cold within ~1,100 km,
+        the enemy is caught unawares and cannot defend for six seconds.<br>
+        <b>H</b> analyse sensor logs (when available)<br>
+        <b>SPACE</b> pause &middot; <b>F</b> fit camera &middot; <b>ESC</b> cancel order mode<br>
+      </div>
+      <div class="ov-rule"></div>
+      <div class="ctl">
+        <b>INCISOR</b> X-ray laser emitters, spinal diamond duster. Fast, evasive.<br>
+        <b>ANNIHILATOR</b> heavy laser grid, antimatter smart-missile swarms from beyond PDC range.<br>
+        <b>CORVETTES</b> your screen. They absorb laser fire and add point-defence against missiles.<br>
+        <b>DUSTERS</b> invisible to radar. When ships start dying without cause, analyse the logs.<br>
+      </div>
+      <button class="big-btn" id="btn-helpclose">RETURN TO CIC</button>
+    </div>
+  </div>
+</div>
+
+<script>
+(function(){
+'use strict';
+
+/* ════════════════════════════════════════════════════════════════════
+   THRESHOLD: FIRST FLEET — real-time tactics, Battle of Threshold, 2909 CE
+   ════════════════════════════════════════════════════════════════════ */
+
+const canvas = document.getElementById('gc');
+const ctx = canvas.getContext('2d');
+let vw = 100, vh = 100, dpr = 1;
+
+const WORLD = { w: 5200, h: 3200 };
+const INTERSTICE = { x: 4650, y: 1600 };
+
+const cam = { x: WORLD.w/2, y: WORLD.h/2, z: 0.3 };
+
+const game = {
+  running: false, paused: false, over: false,
+  t: 0, speed: 1, weaponsFree: false, submm: false,
+  dustHits: 0, analyse: 0, analyseT: 0,    // analyse: 0 hidden 1 avail 2 running 3 done
+  withdrawing: false, endTimer: -1, shake: 0
+};
+
+const stats = { destroyersLost: 0, corvLost: 0, incisors: 0, annihilators: 0, torpsFired: 0, dustFired: 0 };
+
+const groups = [], arco = [], torps = [], rounds = [], missiles = [], dusts = [], beams = [], fx = [];
+
+const GNAMES = ['ISIDORE','JAYAPAL','ACHERON','KEPLER','NOVGOROD','TENACITY','HYPERION','CASTELLAN','RIGA','AMUNDSEN'];
+
+/* ── helpers ─────────────────────────────────────────────────────── */
+const rnd = Math.random;
+function dist(a,b){ return Math.hypot(a.x-b.x, a.y-b.y); }
+function clamp(v,a,b){ return v<a?a:(v>b?b:v); }
+
+function steerTo(e, tx, ty, accel, maxV, dt, arrive){
+  const dx = tx-e.x, dy = ty-e.y, d = Math.hypot(dx,dy) || 1e-6;
+  let sp = maxV;
+  if (arrive) sp = Math.min(maxV, d*1.1);
+  const dvx = dx/d*sp - e.vx, dvy = dy/d*sp - e.vy;
+  const dm = Math.hypot(dvx,dvy) || 1e-6;
+  const am = Math.min(accel*dt, dm);
+  e.vx += dvx/dm*am; e.vy += dvy/dm*am;
+}
+function damp(e, dt){ const f = Math.pow(0.5, dt); e.vx *= f; e.vy *= f; }
+function distToSeg(px, py, x1, y1, x2, y2){
+  const dx = x2-x1, dy = y2-y1;
+  const L2 = dx*dx + dy*dy;
+  const t = L2 ? clamp(((px-x1)*dx + (py-y1)*dy)/L2, 0, 1) : 0;
+  return Math.hypot(px - (x1 + t*dx), py - (y1 + t*dy));
+}
+function lead(sx, sy, t, ps){
+  let tx = t.x, ty = t.y;
+  for (let i=0;i<2;i++){
+    const tt = Math.hypot(tx-sx, ty-sy)/ps;
+    tx = t.x + t.vx*tt; ty = t.y + t.vy*tt;
+  }
+  return { x: tx, y: ty };
+}
+
+/* ── setup ───────────────────────────────────────────────────────── */
+function makeGroup(i){
+  const ang = (-50 + 100*i/9) * Math.PI/180;
+  const x = INTERSTICE.x - Math.cos(ang)*1900;
+  const y = INTERSTICE.y + Math.sin(ang)*1850*0.82;
+  const offs = [];
+  for (let k=0;k<9;k++){ const a = k/9*Math.PI*2; const r = 30 + (k%3)*9; offs.push({a, r}); }
+  return {
+    kind:'union', id:i+1, name:'USV '+GNAMES[i], x, y, vx:0, vy:0,
+    hp:100, maxHp:100, radius:13, angle:0,
+    dest:null, attackTarget:null, torps:36, corvettes:9, corvOff:offs,
+    railCd: rnd()*2, pdcAcc:0, playingDead:false,
+    charging:false, chargeTarget:null, chargeFired:false, chargeT:0,
+    derelict:false, dead:false, surprise:0, flash:0, spin: (rnd()-0.5)*0.6
+  };
+}
+function makeArco(cls, name, hy){
+  const inc = cls === 'incisor';
+  return {
+    kind:'arco', cls, name, x: INTERSTICE.x, y: INTERSTICE.y, vx:-70, vy:0,
+    hp: inc?115:340, maxHp: inc?115:340, radius: inc?15:26, angle: Math.PI,
+    holdX: 4150, holdY: hy, state:'emerge',
+    target:null, retargetT: rnd()*2, jukeT:0, jvx:0, jvy:0,
+    beamCd: 1+rnd()*2, interceptCd: 0,
+    dusterCd: 6+rnd()*6, dusterState: null,
+    missileCd: 14, dead:false, escaped:false, flash:0,
+    evadeT: 0, evadeCd: 0, evx: 0, evy: 0,
+    run: null, runT: 20 + rnd()*15
+  };
+}
+
+const schedule = [];
+function initGame(){
+  groups.length = 0; arco.length = 0;
+  for (let i=0;i<10;i++) groups.push(makeGroup(i));
+  schedule.push(
+    { t: 0.5, fn(){ log('Four contacts emerging from the interstice. Elongated pyramids — spinal weapon mounts.', 'warn'); } },
+    { t: 2,   fn(){ spawnArco('incisor','INCISOR-1',1050); } },
+    { t: 4,   fn(){ spawnArco('incisor','INCISOR-2',1600); } },
+    { t: 6,   fn(){ spawnArco('incisor','INCISOR-3',2150); } },
+    { t: 7,   fn(){ log('Ngoni: ‘Hold position with the interstice. Charge eCell banks. Prep for high-G maneuvers.’', 'quote'); } },
+    { t: 10,  fn(){ spawnArco('annihilator','ANNIHILATOR',1600); log('Fourth contact: capital-class. Designating ANNIHILATOR.', 'warn'); } },
+    { t: 12,  fn(){ log('Comm handshake failing. Software trouble on our end — Striver worms suspected in the network.'); } },
+    { t: 15,  fn(){ malwareLaunch(); } },
+    { t: 18,  fn(){ log('Ngoni: ‘Go manual. Pull the data lines if you have to.’', 'quote'); } },
+    { t: 22,  fn(){
+        game.weaponsFree = true;
+        for (const a of arco) a.state = 'engage';
+        log('ARCO FORCES ENGAGING. WEAPONS FREE.', 'warn');
+        log('Their drives outshine the entire fleet. Accelerations no crew could survive.');
+    } }
+  );
+}
+function spawnArco(cls, name, hy){
+  const a = makeArco(cls, name, hy);
+  arco.push(a);
+  fx.push({ type:'ring', x: INTERSTICE.x, y: INTERSTICE.y, t:0, dur:1.2, maxR:140, color:'rgba(160,200,255,0.8)' });
+  refreshArcoStrip();
+}
+function malwareLaunch(){
+  log('WEAPONS FIRING UNCOMMANDED — torpedo tubes cycling on their own. ‘Fucking Strivers must have worms in our network too.’', 'warn');
+  let n = 0;
+  for (const g of groups){
+    if (n >= 3) break;
+    if (rnd() < 0.5) continue;
+    n++;
+    const tgt = arco[Math.floor(rnd()*arco.length)];
+    if (tgt) fireVolley(g, tgt, 4, true);
+  }
+}
+
+/* ── event log ───────────────────────────────────────────────────── */
+const logEl = document.getElementById('event-log');
+function log(msg, cls){
+  const d = document.createElement('div');
+  d.className = 'ev' + (cls ? ' '+cls : '');
+  const m = Math.floor(game.t/60), s = Math.floor(game.t%60);
+  d.innerHTML = '<span class="ts">'+String(m).padStart(2,'0')+':'+String(s).padStart(2,'0')+'</span>' + msg;
+  logEl.insertBefore(d, logEl.firstChild);
+  while (logEl.children.length > 9) logEl.removeChild(logEl.lastChild);
+}
+
+/* ── combat resolution ───────────────────────────────────────────── */
+function hitGroup(g, dmg, type){
+  if (g.dead) return;
+  if (type === 'laser' && g.corvettes > 0 && rnd() < 0.55){
+    g.corvettes--; stats.corvLost++;
+    fx.push({ type:'boom', x: g.x+(rnd()-0.5)*60, y: g.y+(rnd()-0.5)*60, t:0, dur:0.5, maxR:16, color:'rgba(180,220,255,0.9)' });
+    return;
+  }
+  g.hp -= dmg; g.flash = 0.25;
+  if (g.hp <= 0) destroyGroup(g);
+}
+function destroyGroup(g){
+  if (g.dead) return;
+  g.dead = true; g.hp = 0;
+  stats.destroyersLost++;
+  stats.corvLost += g.corvettes; g.corvettes = 0;
+  selected.delete(g.id);
+  fx.push({ type:'boom', x:g.x, y:g.y, t:0, dur:1.4, maxR:90, color:'rgba(255,200,140,1)' });
+  for (let i=0;i<14;i++) fx.push({ type:'spark', x:g.x, y:g.y, vx:(rnd()-0.5)*220, vy:(rnd()-0.5)*220, t:0, dur:1+rnd(), color:'rgba(255,170,90,0.9)' });
+  game.shake = Math.max(game.shake, 6);
+  log(g.name + ' destroyed.', 'warn');
+  refreshFleetStrip();
+}
+function wreckGroup(g){       // crew dead, hulk drifting
+  if (g.dead || g.derelict) return;
+  g.derelict = true; g.charging = false; g.playingDead = false;
+  stats.destroyersLost++;
+  selected.delete(g.id);
+  refreshFleetStrip();
+}
+function hitArco(a, dmg){
+  if (a.dead) return;
+  a.hp -= dmg; a.flash = 0.25;
+  if (a.hp <= 0){
+    a.dead = true;
+    if (a.cls === 'incisor') stats.incisors++; else stats.annihilators++;
+    fx.push({ type:'boom', x:a.x, y:a.y, t:0, dur:2, maxR:150, color:'rgba(255,235,210,1)' });
+    for (let i=0;i<22;i++) fx.push({ type:'spark', x:a.x, y:a.y, vx:(rnd()-0.5)*320, vy:(rnd()-0.5)*320, t:0, dur:1.4+rnd(), color:'rgba(255,140,80,0.9)' });
+    game.shake = Math.max(game.shake, 10);
+    if (stats.incisors + stats.annihilators === 1)
+      log(a.name + ' DESTROYED — broken in half, consumed in nuclear light. Every hull camera in the fleet recorded it.', 'good');
+    else
+      log(a.name + ' DESTROYED.', 'good');
+    refreshArcoStrip();
+  }
+}
+
+/* ── union actions ───────────────────────────────────────────────── */
+function fireVolley(g, target, n, uncommanded){
+  if (g.dead || g.derelict || g.torps <= 0 || !target || target.dead) return;
+  n = Math.min(n || 6, g.torps);
+  g.torps -= n; stats.torpsFired += n;
+  if (!uncommanded) g.playingDead = false;
+  for (let i=0;i<n;i++){
+    const a = rnd()*Math.PI*2;
+    torps.push({
+      x: g.x + Math.cos(a)*16, y: g.y + Math.sin(a)*16,
+      vx: g.vx + (rnd()-0.5)*60, vy: g.vy + (rnd()-0.5)*60,
+      target, life: 26, dead: false, sneak: g.surprise > 0
+    });
+  }
+  g.flash = 0.15;
+}
+function orderCharge(g, target){
+  if (g.dead || g.derelict || g.charging) return;
+  const sneak = g.playingDead && dist(g, target) < 1100;
+  g.charging = true; g.chargeTarget = target; g.chargeFired = false; g.chargeT = 0;
+  g.playingDead = false; g.dest = null; g.attackTarget = null;
+  if (sneak){ g.surprise = 6; log(g.name + ' — cold hull igniting at point-blank range. They never saw it coming.', 'good'); }
+  if (g.name === 'USV ISIDORE') log('Ngoni: ‘This is it.’', 'quote');
+  else log(g.name + ': ‘It’s been a privilege.’', 'quote');
+  log(g.name + ' burning at THIRTY GRAVITIES. The crew will not survive the burn.', 'warn');
+}
+
+/* ── update: union ───────────────────────────────────────────────── */
+function updateGroup(g, dt){
+  if (g.dead) return;
+  g.flash = Math.max(0, g.flash - dt);
+  g.surprise = Math.max(0, g.surprise - dt);
+
+  if (g.derelict){
+    g.x += g.vx*dt; g.y += g.vy*dt;
+    damp(g, dt*0.1);
+    return;
+  }
+
+  /* movement */
+  if (g.charging){
+    const t = g.chargeTarget;
+    g.chargeT += dt;
+    if (!t || t.dead){
+      wreckGroup(g);   // burn already redlined the drive
+    } else {
+      steerTo(g, t.x, t.y, 95, 430, dt, false);
+      const d = dist(g, t);
+      if (!g.chargeFired && d < 420){
+        fireVolley(g, t, g.torps, true);
+        g.chargeFired = true;
+      }
+      if (d < t.radius + 20){
+        hitArco(t, 70);
+        fx.push({ type:'boom', x:g.x, y:g.y, t:0, dur:1.6, maxR:120, color:'rgba(255,255,230,1)' });
+        wreckGroup(g);
+      } else if (g.chargeFired && g.chargeT > 0 && d > 600){
+        wreckGroup(g);   // overshot; drive slagged, crew gone
+      } else if (g.chargeT > 22){
+        wreckGroup(g);
+      }
+    }
+  } else if (g.playingDead){
+    damp(g, dt);
+  } else if (g.attackTarget && !g.attackTarget.dead){
+    const t = g.attackTarget;
+    const d = dist(g, t);
+    if (d > 720) steerTo(g, t.x, t.y, 26, 105, dt, false);
+    else damp(g, dt);
+  } else if (g.dest){
+    steerTo(g, g.dest.x, g.dest.y, 26, 105, dt, true);
+    if (dist(g, g.dest) < 18) g.dest = null;
+  } else {
+    damp(g, dt);
+  }
+  g.x = clamp(g.x + g.vx*dt, 30, WORLD.w-30);
+  g.y = clamp(g.y + g.vy*dt, 30, WORLD.h-30);
+  const sp = Math.hypot(g.vx, g.vy);
+  if (sp > 12) g.angle = Math.atan2(g.vy, g.vx);
+
+  /* railgun */
+  if (!g.playingDead && !g.charging && game.weaponsFree){
+    g.railCd -= dt;
+    if (g.railCd <= 0){
+      /* ordered targets engaged at full range; otherwise defensive fire only at close quarters */
+      let tgt = (g.attackTarget && !g.attackTarget.dead && dist(g,g.attackTarget) < 1050) ? g.attackTarget : null;
+      if (!tgt){
+        let bd = 450;
+        for (const a of arco){ if (a.dead || a.escaped) continue; const d = dist(g,a); if (d < bd){ bd = d; tgt = a; } }
+      }
+      if (tgt){
+        const L = lead(g.x, g.y, tgt, 620);
+        /* dispersion grows with range — railguns are close-quarters weapons */
+        const err = 0.012 + dist(g, tgt)/1050*0.085;
+        const a = Math.atan2(L.y-g.y, L.x-g.x) + (rnd()-0.5)*2*err;
+        rounds.push({ x:g.x, y:g.y, vx: Math.cos(a)*620 + g.vx*0.3, vy: Math.sin(a)*620 + g.vy*0.3, life: 3.2 });
+        g.railCd = 2.4;
+        g.flash = Math.max(g.flash, 0.08);
+      }
+    }
+  }
+
+  /* PDC vs missiles */
+  if (!g.playingDead && game.weaponsFree){
+    g.pdcAcc += dt * (0.8 + g.corvettes*0.18);
+    while (g.pdcAcc >= 1){
+      g.pdcAcc -= 1;
+      let tgt = null, bd = 290;
+      for (const m of missiles){ if (m.dead) continue; const d = dist(g,m); if (d < bd){ bd = d; tgt = m; } }
+      if (tgt){
+        beams.push({ x1:g.x, y1:g.y, x2:tgt.x, y2:tgt.y, life:0.1, color:'rgba(160,255,200,0.7)', w:1 });
+        if (rnd() < 0.6){
+          tgt.dead = true;
+          fx.push({ type:'boom', x:tgt.x, y:tgt.y, t:0, dur:0.4, maxR:14, color:'rgba(200,255,220,0.9)' });
+        }
+      } else { g.pdcAcc = 0; break; }
+    }
+  }
+}
+
+/* ── update: arco ────────────────────────────────────────────────── */
+function pickUnionTarget(a, range){
+  let best = null, bs = Infinity;
+  for (const g of groups){
+    if (g.dead || g.derelict || g.surprise > 0) continue;
+    const d = dist(a, g);
+    if (d > range) continue;
+    if (g.playingDead && d > 350) continue;
+    const score = d * (g.playingDead ? 4 : 1);
+    if (score < bs){ bs = score; best = g; }
+  }
+  return best;
+}
+function updateArco(a, dt){
+  if (a.dead || a.escaped) return;
+  a.flash = Math.max(0, a.flash - dt);
+  const inc = a.cls === 'incisor';
+
+  /* movement */
+  if (a.state === 'emerge'){
+    steerTo(a, a.holdX, a.holdY, 40, 160, dt, true);
+    if (dist(a, {x:a.holdX, y:a.holdY}) < 60) a.state = 'hold';
+  } else if (a.state === 'hold'){
+    damp(a, dt);
+  } else if (a.state === 'withdraw'){
+    steerTo(a, INTERSTICE.x, INTERSTICE.y, inc?70:16, (inc?175:80)*1.2, dt, false);
+    if (dist(a, INTERSTICE) < 130){
+      a.escaped = true;
+      fx.push({ type:'ring', x:INTERSTICE.x, y:INTERSTICE.y, t:0, dur:1, maxR:120, color:'rgba(160,200,255,0.7)' });
+      refreshArcoStrip();
+      return;
+    }
+  } else if (a.state === 'engage'){
+    a.retargetT -= dt;
+    if (a.retargetT <= 0 || !a.target || a.target.dead || a.target.derelict){
+      a.target = pickUnionTarget(a, 99999);
+      a.retargetT = 4 + rnd()*2;
+    }
+    if (inc){
+      if (a.target){
+        const t = a.target, d = dist(a,t);
+        const hurt = a.hp < 45;          // wounded: break off, fight from standoff
+        a.runT -= dt;
+        if (hurt && a.run) a.run = null;
+        if (!a.run && a.runT <= 0 && !hurt){
+          /* attack run: dive through the formation at full burn */
+          a.run = { phase: 'in' };
+        }
+        if (a.run){
+          if (a.run.phase === 'in'){
+            steerTo(a, t.x, t.y, 90, 200, dt, false);
+            if (d < 300){
+              const ang = Math.atan2(a.vy, a.vx);
+              a.run = { phase: 'out', x: a.x + Math.cos(ang)*1400, y: a.y + Math.sin(ang)*1400 };
+            }
+          } else {
+            steerTo(a, a.run.x, a.run.y, 90, 200, dt, false);
+            if (dist(a, a.run) < 120){ a.run = null; a.runT = 24 + rnd()*14; }
+          }
+        } else {
+          /* standoff orbit at ~1150 — outside railgun envelope, inside laser/duster range */
+          a.jukeT -= dt;
+          if (a.jukeT <= 0){
+            const ang = Math.atan2(t.y-a.y, t.x-a.x) + Math.PI/2;
+            const s = rnd() < 0.5 ? 1 : -1;
+            a.jvx = Math.cos(ang)*s*140; a.jvy = Math.sin(ang)*s*140;
+            a.jukeT = 1 + rnd()*1.2;
+          }
+          const ang2 = Math.atan2(a.y-t.y, a.x-t.x);
+          const so = hurt ? 1650 : 1150;
+          const px = t.x + Math.cos(ang2+0.4)*so + a.jvx;
+          const py = t.y + Math.sin(ang2+0.4)*so + a.jvy;
+          steerTo(a, px, py, 70, 175, dt, false);
+        }
+      } else damp(a, dt);
+    } else {
+      /* annihilator: creep toward fleet centroid, keep range */
+      let cx=0, cy=0, n=0;
+      for (const g of groups){ if (!g.dead && !g.derelict){ cx+=g.x; cy+=g.y; n++; } }
+      if (n){
+        cx/=n; cy/=n;
+        const d = Math.hypot(cx-a.x, cy-a.y);
+        if (d > 1500) steerTo(a, cx, cy, 16, 80, dt, false);
+        else damp(a, dt);
+      } else damp(a, dt);
+    }
+  }
+  /* active evasion vs railgun rounds — long shots get dodged, point-blank
+     and multi-angle saturation gets through */
+  a.evadeT = Math.max(0, a.evadeT - dt);
+  a.evadeCd = Math.max(0, a.evadeCd - dt);
+  if (a.evadeCd <= 0 && (a.state === 'engage' || a.state === 'withdraw')){
+    for (const r of rounds){
+      if (r.dead) continue;
+      const dx = a.x-r.x, dy = a.y-r.y;
+      const rs = Math.hypot(r.vx, r.vy) || 1;
+      const ux = r.vx/rs, uy = r.vy/rs;
+      const along = dx*ux + dy*uy;
+      if (along < 0) continue;
+      const off = dy*ux - dx*uy;
+      const tti = along/rs;
+      if (Math.abs(off) < a.radius + 26 && tti > 0.18 && tti < 0.85){
+        const s = off >= 0 ? 1 : -1;
+        const pw = inc ? 200 : 55;
+        a.evx = -uy*s*pw; a.evy = ux*s*pw;
+        a.evadeT = 0.4;
+        a.evadeCd = 0.45 + rnd()*0.3;
+        break;
+      }
+    }
+  }
+  if (a.evadeT > 0){ a.vx += a.evx*dt; a.vy += a.evy*dt; }
+
+  a.x += a.vx*dt; a.y += a.vy*dt;
+  const sp = Math.hypot(a.vx, a.vy);
+  if (a.dusterState && a.dusterState.target && !a.dusterState.target.dead)
+    a.angle = Math.atan2(a.dusterState.target.y-a.y, a.dusterState.target.x-a.x);
+  else if (a.target && !a.target.dead && a.state==='engage')
+    a.angle = Math.atan2(a.target.y-a.y, a.target.x-a.x);
+  else if (sp > 10) a.angle = Math.atan2(a.vy, a.vx);
+
+  if (a.state !== 'engage' && a.state !== 'withdraw') return;
+
+  /* laser torpedo interception */
+  a.interceptCd -= dt;
+  let guard = 8;
+  while (a.interceptCd <= 0 && guard-- > 0){
+    let tgt = null, bd = 1500;
+    for (const t of torps){
+      if (t.dead) continue;
+      const d = dist(a, t);
+      if (t.sneak && d > 500) continue;
+      if (d < bd){ bd = d; tgt = t; }
+    }
+    if (tgt){
+      tgt.dead = true;
+      beams.push({ x1:a.x, y1:a.y, x2:tgt.x, y2:tgt.y, life:0.12, color:'rgba(220,240,255,0.85)', w:1.2 });
+      fx.push({ type:'boom', x:tgt.x, y:tgt.y, t:0, dur:0.35, maxR:10, color:'rgba(220,240,255,0.8)' });
+      a.interceptCd += inc ? 0.38 : 0.2;
+    } else { a.interceptCd = 0; break; }
+  }
+
+  if (a.state === 'withdraw') return;   // defensive lasers only while leaving
+
+  /* offensive beam */
+  a.beamCd -= dt;
+  if (a.beamCd <= 0){
+    const tgt = pickUnionTarget(a, inc ? 1250 : 1500);
+    if (tgt){
+      beams.push({ x1:a.x, y1:a.y, x2:tgt.x, y2:tgt.y, life:0.2, color:'rgba(255,235,255,0.95)', w:2.2 });
+      hitGroup(tgt, inc ? 8 : 14, 'laser');
+      a.beamCd = inc ? 3.6 : 4.0;
+    } else a.beamCd = 0.5;
+  }
+
+  /* duster (incisors) */
+  if (inc){
+    a.dusterCd -= dt;
+    if (!a.dusterState && a.dusterCd <= 0){
+      const tgt = pickUnionTarget(a, 1900);
+      if (tgt) a.dusterState = { t: 2.6, target: tgt };
+    }
+    if (a.dusterState){
+      a.dusterState.t -= dt;
+      const tgt = a.dusterState.target;
+      if (!tgt || tgt.dead || tgt.derelict){ a.dusterState = null; a.dusterCd = 3; }
+      else if (a.dusterState.t <= 0){
+        const L = lead(a.x, a.y, tgt, 1200);
+        const ang = Math.atan2(L.y-a.y, L.x-a.x);
+        stats.dustFired++;
+        dusts.push({
+          x: a.x, y: a.y, vx: Math.cos(ang)*1200, vy: Math.sin(ang)*1200,
+          target: tgt, life: 3.5, resolved: false
+        });
+        a.dusterState = null;
+        a.dusterCd = 8 + rnd()*4;
+      }
+    }
+  }
+
+  /* missiles (annihilator) */
+  if (!inc){
+    a.missileCd -= dt;
+    if (a.missileCd <= 0){
+      const live = groups.filter(g => !g.dead && !g.derelict && (!g.playingDead || dist(a,g) < 350));
+      if (live.length){
+        for (let i=0;i<7;i++){
+          const tgt = live[Math.floor(rnd()*live.length)];
+          missiles.push({
+            x: a.x + (rnd()-0.5)*40, y: a.y + (rnd()-0.5)*40,
+            vx: a.vx + (rnd()-0.5)*120, vy: a.vy + (rnd()-0.5)*120,
+            target: tgt, life: 30, dead: false
+          });
+        }
+        log('Annihilator launching smart missiles — 200G acceleration and climbing.', 'warn');
+        a.missileCd = 26;
+      } else a.missileCd = 4;
+    }
+  }
+}
+
+/* ── projectiles ─────────────────────────────────────────────────── */
+function updateProjectiles(dt){
+  /* torpedoes */
+  for (const t of torps){
+    if (t.dead) continue;
+    t.life -= dt;
+    if (t.life <= 0){ t.dead = true; continue; }
+    if (!t.target || t.target.dead){
+      let bd = Infinity, nt = null;
+      for (const a of arco){ if (a.dead || a.escaped) continue; const d = dist(t,a); if (d < bd){ bd = d; nt = a; } }
+      t.target = nt;
+      if (!nt){ t.dead = true; continue; }
+    }
+    const L = lead(t.x, t.y, t.target, Math.max(200, Math.hypot(t.vx,t.vy)));
+    steerTo(t, L.x, L.y, 150, 400, dt, false);
+    t.x += t.vx*dt; t.y += t.vy*dt;
+    if (dist(t, t.target) < t.target.radius + 9){
+      t.dead = true;
+      hitArco(t.target, 9);
+      fx.push({ type:'boom', x:t.x, y:t.y, t:0, dur:0.6, maxR:30, color:'rgba(255,220,160,0.95)' });
+    }
+  }
+  /* railgun rounds */
+  for (const r of rounds){
+    if (r.dead) continue;
+    r.life -= dt;
+    if (r.life <= 0){ r.dead = true; continue; }
+    r.x += r.vx*dt; r.y += r.vy*dt;
+    for (const a of arco){
+      if (a.dead || a.escaped) continue;
+      if (dist(r, a) < a.radius + 5){
+        r.dead = true;
+        hitArco(a, 7);
+        fx.push({ type:'boom', x:r.x, y:r.y, t:0, dur:0.4, maxR:16, color:'rgba(255,200,160,0.9)' });
+        break;
+      }
+    }
+  }
+  /* missiles */
+  for (const m of missiles){
+    if (m.dead) continue;
+    m.life -= dt;
+    if (m.life <= 0){ m.dead = true; continue; }
+    if (!m.target || m.target.dead){
+      let bd = Infinity, nt = null;
+      for (const g of groups){ if (g.dead || g.derelict) continue; const d = dist(m,g); if (d < bd){ bd = d; nt = g; } }
+      m.target = nt;
+      if (!nt){ m.dead = true; continue; }
+    }
+    const L = lead(m.x, m.y, m.target, Math.max(220, Math.hypot(m.vx,m.vy)));
+    steerTo(m, L.x, L.y, 220, 540, dt, false);
+    m.x += m.vx*dt; m.y += m.vy*dt;
+    if (dist(m, m.target) < 230){
+      m.dead = true;
+      /* antimatter standoff detonation: gamma burst */
+      fx.push({ type:'gamma', x:m.x, y:m.y, t:0, dur:0.8, maxR:230, color:'rgba(220,180,255,0.9)' });
+      hitGroup(m.target, 13, 'blast');
+      if (m.target.corvettes > 0){ const k = Math.min(m.target.corvettes, 2); m.target.corvettes -= k; stats.corvLost += k; }
+      for (const g of groups){
+        if (g === m.target || g.dead) continue;
+        if (dist(m, g) < 280) hitGroup(g, 6, 'blast');
+      }
+      game.shake = Math.max(game.shake, 3);
+    }
+  }
+  /* duster streams */
+  for (const d of dusts){
+    if (d.resolved && d.life < -1) continue;
+    d.life -= dt;
+    const px = d.x, py = d.y;
+    d.x += d.vx*dt; d.y += d.vy*dt;
+    if (d.life <= 0){ d.resolved = true; continue; }
+    if (!d.resolved){
+      for (const g of groups){
+        if (g.dead) continue;
+        if (distToSeg(g.x, g.y, px, py, d.x, d.y) < 60){
+          d.resolved = true;
+          const hitChance = game.submm ? 0.3 : 0.92;
+          if (rnd() < hitChance){
+            const k = Math.min(g.corvettes, 3);
+            g.corvettes -= k; stats.corvLost += k;
+            g.hp -= 26 + rnd()*14; g.flash = 0.3;
+            fx.push({ type:'boom', x:g.x, y:g.y, t:0, dur:1, maxR:60, color:'rgba(255,160,120,1)' });
+            game.shake = Math.max(game.shake, 5);
+            game.dustHits++;
+            if (g.hp <= 0) destroyGroup(g);
+            else if (!game.submm) log(g.name + ' — multiple hull breaches, milliseconds apart. No incoming fire detected.', 'warn');
+            if (game.dustHits === 1 && game.analyse === 0){
+              game.analyse = 1;
+              document.getElementById('analyse-btn').style.display = 'block';
+              log('Ships are dying with no apparent cause. Someone needs to go through the raw sensor logs. [H]', 'warn');
+            }
+          } else if (game.submm){
+            fx.push({ type:'ring', x:g.x, y:g.y, t:0, dur:0.5, maxR:50, color:'rgba(255,120,90,0.5)' });
+          }
+          break;
+        }
+      }
+    }
+  }
+  /* beams + fx decay */
+  for (const b of beams) b.life -= dt;
+  for (const f of fx) f.t += dt;
+}
+
+/* ── analyse / submm unlock ──────────────────────────────────────── */
+function startAnalyse(){
+  if (game.analyse !== 1) return;
+  game.analyse = 2; game.analyseT = 4;
+  log('Pulling the Jayapal’s full sensor log — anti-collision radar, non-tactical channels, everything.');
+}
+function finishAnalyse(){
+  game.analyse = 3; game.submm = true;
+  document.getElementById('analyse-btn').style.display = 'none';
+  log('Hansun: ‘They’re using dusters. Spinal mounts are hypervelocity micron-particle accelerators — projectiles too small for radar.’', 'quote');
+  log('Radar switched to submillimetre band. Incoming dust streams now visible. Evasion solutions loaded.', 'good');
+}
+
+/* ── end conditions ──────────────────────────────────────────────── */
+function activeUnion(){ return groups.filter(g => !g.dead && !g.derelict).length; }
+function checkEnd(dt){
+  if (game.over) return;
+  const arcoLeft = arco.filter(a => !a.dead && !a.escaped);
+  const arcoKilled = stats.incisors + stats.annihilators;
+
+  if (!game.withdrawing && game.weaponsFree && arcoLeft.length &&
+      (game.t > 480 || activeUnion() <= 2)){
+    game.withdrawing = true;
+    for (const a of arcoLeft) a.state = 'withdraw';
+    log('Arco forces vectoring back toward the interstice, like nothing had happened.', 'warn');
+  }
+  const unionGone = activeUnion() === 0;
+  const arcoGone = arcoLeft.length === 0 && arco.length === 4;
+  if ((unionGone || arcoGone) && game.endTimer < 0) game.endTimer = 2.5;
+  if (game.endTimer >= 0){
+    game.endTimer -= dt;
+    if (game.endTimer <= 0) endGame();
+  }
+}
+function endGame(){
+  if (game.over) return;
+  game.over = true; game.running = false;
+  const kills = stats.incisors + stats.annihilators;
+  const survivors = activeUnion();
+  let title, sub, quote;
+  if (kills >= 4){
+    title = 'IMPOSSIBLE VICTORY'; sub = 'ALL FOUR ARCO WARSHIPS DESTROYED';
+    quote = 'No fleet in Union history has done what you just did. The interstice is yours — and so is whatever comes through it next.';
+  } else if (kills === 3){
+    title = 'THE FLEET HOLDS'; sub = 'THREE ARCO WARSHIPS DESTROYED';
+    quote = 'Three pyramids broken. The survivors limp home through a sky full of wreckage, and the recruiters will never want for volunteers again.';
+  } else if (kills === 2){
+    title = 'BEYOND THE ISIDORE'; sub = 'TWO ARCO WARSHIPS DESTROYED';
+    quote = 'Twice the toll history recorded. The clips will be plastered everywhere — licenced and unlicenced feeds, graffiti prints, posters.';
+  } else if (kills === 1){
+    title = 'HISTORY REPEATS'; sub = 'ONE INCISOR DESTROYED';
+    quote = 'Three ships returned through the interstice, not four. Exactly as the record shows. Somewhere in the wreckage, an ensign is waking up alone.';
+  } else if (survivors > 0){
+    title = 'WITHDRAWAL'; sub = 'NO ARCO LOSSES';
+    quote = 'The invaders vectored right around and headed back into the interstice like nothing had happened. Nobody cheered.';
+  } else {
+    title = 'ANNIHILATION'; sub = 'FIRST FLEET DESTROYED — NO ARCO LOSSES';
+    quote = 'Not even the Isidore’s charge. History will record only the dying.';
+  }
+  document.getElementById('aftermath-title').textContent = title;
+  document.getElementById('aftermath-title').style.color = kills > 0 ? 'var(--accent)' : '#ff6b50';
+  document.getElementById('aftermath-sub').textContent = sub;
+  const shipsLost = stats.destroyersLost*1 + stats.corvLost;
+  document.getElementById('aftermath-stats').innerHTML =
+    '<div class="stat-row"><span>ENGAGEMENT DURATION</span><span>' + Math.floor(game.t/60)+'m '+Math.floor(game.t%60)+'s</span></div>' +
+    '<div class="stat-row"><span>DESTROYERS LOST</span><span>' + stats.destroyersLost + ' / 10</span></div>' +
+    '<div class="stat-row"><span>CORVETTES LOST</span><span>' + stats.corvLost + ' / 90</span></div>' +
+    '<div class="stat-row"><span>TOTAL SHIPS LOST</span><span>' + shipsLost + ' / 100</span></div>' +
+    '<div class="stat-row"><span>TORPEDOES EXPENDED</span><span>' + stats.torpsFired + '</span></div>' +
+    '<div class="stat-row"><span>INCISORS DESTROYED</span><span>' + stats.incisors + ' / 3</span></div>' +
+    '<div class="stat-row"><span>ANNIHILATOR DESTROYED</span><span>' + (stats.annihilators ? 'YES' : 'NO') + '</span></div>';
+  document.getElementById('aftermath-quote').textContent = quote;
+  document.getElementById('aftermath-canon').innerHTML =
+    'HISTORICAL RECORD &mdash; 2909 CE: 97 of 100 Union ships lost. One Incisor destroyed, by the USV Isidore&rsquo;s ' +
+    'thirty-gee suicide charge. Captain Ngoni died in her acceleration couch. Sole survivor: Ensign Hansun.';
+  document.getElementById('aftermath').style.display = 'flex';
+}
+
+/* ── selection & input ───────────────────────────────────────────── */
+const selected = new Set();
+let mode = null;          // null | 'volley' | 'charge'
+let dragStart = null, dragNow = null, panning = false, panLast = null;
+
+function setMode(m){
+  mode = m;
+  const b = document.getElementById('mode-banner');
+  if (m === 'volley'){
+    b.style.display = 'block'; b.className = '';
+    b.textContent = 'DESIGNATE TORPEDO VOLLEY TARGET — ESC TO CANCEL';
+  } else if (m === 'charge'){
+    b.style.display = 'block'; b.className = 'danger';
+    b.textContent = 'DESIGNATE 30G CHARGE TARGET — THE CREW WILL NOT SURVIVE — ESC TO CANCEL';
+  } else b.style.display = 'none';
+  document.getElementById('btn-volley').classList.toggle('armed', m==='volley');
+  document.getElementById('btn-charge').classList.toggle('armed', m==='charge');
+}
+function selectedGroups(){ return groups.filter(g => selected.has(g.id) && !g.dead && !g.derelict); }
+function selectAll(){
+  selected.clear();
+  for (const g of groups) if (!g.dead && !g.derelict) selected.add(g.id);
+  refreshFleetStrip();
+}
+
+function screenToWorld(px, py){ return { x: (px - vw/2)/cam.z + cam.x, y: (py - vh/2)/cam.z + cam.y }; }
+function worldToScreen(x, y){ return { x: (x - cam.x)*cam.z + vw/2, y: (y - cam.y)*cam.z + vh/2 }; }
+
+function arcoAt(wp){
+  for (const a of arco){
+    if (a.dead || a.escaped) continue;
+    if (Math.hypot(a.x-wp.x, a.y-wp.y) < Math.max(a.radius+10, 26/cam.z)) return a;
+  }
+  return null;
+}
+function groupAt(wp){
+  for (const g of groups){
+    if (g.dead) continue;
+    if (Math.hypot(g.x-wp.x, g.y-wp.y) < Math.max(g.radius+12, 26/cam.z)) return g;
+  }
+  return null;
+}
+
+function handlePrimary(px, py, additive){
+  const wp = screenToWorld(px, py);
+  if (mode){
+    const a = arcoAt(wp);
+    if (a){
+      const sel = selectedGroups();
+      if (!sel.length){ log('No battlegroups selected.'); setMode(null); return; }
+      if (mode === 'volley'){
+        if (!game.weaponsFree){ log('WEAPONS HOLD — Admiral’s orders. Projectile fire may be read as hostile action.', 'warn'); setMode(null); return; }
+        let fired = 0;
+        for (const g of sel){ if (g.torps > 0){ fireVolley(g, a, 6, false); fired++; } }
+        if (!fired) log('Torpedo magazines empty.');
+      } else if (mode === 'charge'){
+        if (!game.weaponsFree){ log('WEAPONS HOLD — Admiral’s orders.', 'warn'); setMode(null); return; }
+        for (const g of sel) orderCharge(g, a);
+      }
+      setMode(null);
+    } else setMode(null);
+    return;
+  }
+  const g = groupAt(wp);
+  if (g && !g.derelict){
+    if (!additive) selected.clear();
+    if (additive && selected.has(g.id)) selected.delete(g.id); else selected.add(g.id);
+  } else if (!additive){
+    selected.clear();
+  }
+  refreshFleetStrip();
+}
+function handleOrder(px, py){
+  const wp = screenToWorld(px, py);
+  const sel = selectedGroups();
+  if (!sel.length) return;
+  const a = arcoAt(wp);
+  if (a){
+    for (const g of sel){ g.attackTarget = a; g.dest = null; g.playingDead = false; }
+    fx.push({ type:'ring', x:a.x, y:a.y, t:0, dur:0.5, maxR:34, color:'rgba(255,120,90,0.8)' });
+  } else {
+    const n = sel.length;
+    sel.forEach((g, i) => {
+      const ang = i/n*Math.PI*2, r = n > 1 ? 70 : 0;
+      g.dest = { x: clamp(wp.x + Math.cos(ang)*r, 30, WORLD.w-30), y: clamp(wp.y + Math.sin(ang)*r, 30, WORLD.h-30) };
+      g.attackTarget = null; g.playingDead = false;
+    });
+    fx.push({ type:'ring', x:wp.x, y:wp.y, t:0, dur:0.5, maxR:30, color:'rgba(0,229,255,0.7)' });
+  }
+}
+
+canvas.addEventListener('mousedown', e => {
+  const r = canvas.getBoundingClientRect();
+  const px = e.clientX - r.left, py = e.clientY - r.top;
+  if (e.button === 0){ dragStart = { x: px, y: py }; dragNow = { x: px, y: py }; }
+  else if (e.button === 1){ panning = true; panLast = { x: px, y: py }; e.preventDefault(); }
+});
+canvas.addEventListener('mousemove', e => {
+  const r = canvas.getBoundingClientRect();
+  const px = e.clientX - r.left, py = e.clientY - r.top;
+  if (dragStart) dragNow = { x: px, y: py };
+  if (panning && panLast){
+    cam.x -= (px - panLast.x)/cam.z; cam.y -= (py - panLast.y)/cam.z;
+    panLast = { x: px, y: py };
+  }
+});
+window.addEventListener('mouseup', e => {
+  if (e.button === 1){ panning = false; return; }
+  if (e.button !== 0 || !dragStart) return;
+  const moved = dragNow && Math.hypot(dragNow.x-dragStart.x, dragNow.y-dragStart.y) > 7;
+  if (moved && !mode){
+    const a = screenToWorld(Math.min(dragStart.x, dragNow.x), Math.min(dragStart.y, dragNow.y));
+    const b = screenToWorld(Math.max(dragStart.x, dragNow.x), Math.max(dragStart.y, dragNow.y));
+    if (!e.shiftKey && !e.ctrlKey) selected.clear();
+    for (const g of groups){
+      if (g.dead || g.derelict) continue;
+      if (g.x >= a.x && g.x <= b.x && g.y >= a.y && g.y <= b.y) selected.add(g.id);
+    }
+    refreshFleetStrip();
+  } else {
+    handlePrimary(dragStart.x, dragStart.y, e.shiftKey || e.ctrlKey);
+  }
+  dragStart = dragNow = null;
+});
+canvas.addEventListener('contextmenu', e => {
+  e.preventDefault();
+  const r = canvas.getBoundingClientRect();
+  if (mode){ setMode(null); return; }
+  handleOrder(e.clientX - r.left, e.clientY - r.top);
+});
+canvas.addEventListener('wheel', e => {
+  e.preventDefault();
+  const r = canvas.getBoundingClientRect();
+  const px = e.clientX - r.left, py = e.clientY - r.top;
+  const before = screenToWorld(px, py);
+  const fit = Math.min(vw/WORLD.w, vh/WORLD.h);
+  cam.z = clamp(cam.z * (e.deltaY < 0 ? 1.15 : 0.87), fit*0.85, fit*6);
+  const after = screenToWorld(px, py);
+  cam.x += before.x - after.x; cam.y += before.y - after.y;
+}, { passive: false });
+
+/* touch: tap = select / order */
+let touchStart = null;
+canvas.addEventListener('touchstart', e => {
+  if (e.touches.length === 1){
+    const r = canvas.getBoundingClientRect();
+    touchStart = { x: e.touches[0].clientX - r.left, y: e.touches[0].clientY - r.top, t: Date.now() };
+  }
+}, { passive: true });
+canvas.addEventListener('touchend', e => {
+  if (!touchStart) return;
+  const px = touchStart.x, py = touchStart.y;
+  const wp = screenToWorld(px, py);
+  const g = groupAt(wp), a = arcoAt(wp);
+  if (mode){ handlePrimary(px, py, false); }
+  else if (g && !g.derelict){ handlePrimary(px, py, false); }
+  else if (a && selectedGroups().length){ handleOrder(px, py); }
+  else if (selectedGroups().length){ handleOrder(px, py); }
+  else handlePrimary(px, py, false);
+  touchStart = null;
+}, { passive: true });
+
+window.addEventListener('keydown', e => {
+  if (e.repeat) return;
+  const k = e.key.toLowerCase();
+  if (k === ' '){ e.preventDefault(); togglePause(); return; }
+  if (k === 'escape'){ setMode(null); return; }
+  if (k === 'a'){ selectAll(); return; }
+  if (k === 't'){ setMode(mode === 'volley' ? null : 'volley'); return; }
+  if (k === 'x'){ setMode(mode === 'charge' ? null : 'charge'); return; }
+  if (k === 'd'){ togglePlayDead(); return; }
+  if (k === 'h'){ startAnalyse(); return; }
+  if (k === 'f'){ fitCamera(); return; }
+  if (k === 'arrowleft') cam.x -= 120/cam.z;
+  if (k === 'arrowright') cam.x += 120/cam.z;
+  if (k === 'arrowup') cam.y -= 120/cam.z;
+  if (k === 'arrowdown') cam.y += 120/cam.z;
+  if (/^[0-9]$/.test(k)){
+    const id = k === '0' ? 10 : parseInt(k, 10);
+    const g = groups[id-1];
+    if (g && !g.dead && !g.derelict){
+      if (!e.shiftKey) selected.clear();
+      selected.add(id);
+      refreshFleetStrip();
+    }
+  }
+});
+function togglePlayDead(){
+  const sel = selectedGroups();
+  if (!sel.length) return;
+  const anyLive = sel.some(g => !g.playingDead);
+  for (const g of sel){
+    if (g.charging) continue;
+    g.playingDead = anyLive;
+    if (anyLive){ g.dest = null; g.attackTarget = null; }
+  }
+  if (anyLive) log('Going dark — drives cold, weapons stowed, signature down.');
+}
+
+/* ── camera / canvas ─────────────────────────────────────────────── */
+function fitCamera(){
+  cam.x = WORLD.w/2; cam.y = WORLD.h/2;
+  cam.z = Math.min(vw/WORLD.w, vh/WORLD.h) * 0.96;
+}
+function resize(){
+  const root = document.getElementById('game-root');
+  vw = root.clientWidth; vh = root.clientHeight;
+  dpr = window.devicePixelRatio || 1;
+  canvas.width = vw*dpr; canvas.height = vh*dpr;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+}
+window.addEventListener('resize', () => { resize(); fitCamera(); });
+
+/* ── HUD strips ──────────────────────────────────────────────────── */
+const fleetEl = document.getElementById('fleet-strip');
+const arcoEl = document.getElementById('arco-strip');
+function refreshFleetStrip(){
+  fleetEl.innerHTML = '';
+  groups.forEach(g => {
+    const c = document.createElement('div');
+    c.className = 'fs-cell' + (selected.has(g.id) ? ' sel' : '') + ((g.dead || g.derelict) ? ' lost' : '');
+    c.textContent = g.id === 10 ? '0' : String(g.id);
+    c.title = g.name;
+    if (!g.dead && !g.derelict){
+      const b = document.createElement('span'); b.className = 'bar';
+      b.style.width = Math.round(g.hp/g.maxHp*100) + '%';
+      if (g.hp < 35) b.style.background = '#ff5040';
+      c.appendChild(b);
+    }
+    c.addEventListener('click', () => {
+      if (g.dead || g.derelict) return;
+      selected.clear(); selected.add(g.id); refreshFleetStrip();
+    });
+    fleetEl.appendChild(c);
+  });
+}
+function refreshArcoStrip(){
+  arcoEl.innerHTML = '';
+  arco.forEach(a => {
+    const c = document.createElement('div');
+    c.className = 'as-cell' + ((a.dead || a.escaped) ? ' lost' : '');
+    c.textContent = a.name + (a.escaped ? ' [WITHDREW]' : '');
+    const b = document.createElement('span'); b.className = 'bar';
+    b.style.width = a.dead ? '0%' : Math.round(a.hp/a.maxHp*100) + '%';
+    c.appendChild(b);
+    arcoEl.appendChild(c);
+  });
+}
+
+/* bottom selection panel — rebuilt on a timer */
+const selPanel = document.getElementById('sel-panel');
+setInterval(() => {
+  if (game.over) return;
+  const sel = groups.filter(g => selected.has(g.id));
+  selPanel.innerHTML = sel.slice(0, 6).map(g =>
+    '<div class="sel-card' + (g.playingDead ? ' cold' : '') + '">' +
+    '<div class="nm">' + g.name + (g.playingDead ? ' · COLD' : g.charging ? ' · 30G BURN' : '') + '</div>' +
+    '<div class="hpb"><i style="width:' + Math.round(g.hp/g.maxHp*100) + '%' + (g.hp<35?';background:#ff5040':'') + '"></i></div>' +
+    'TORPS ' + g.torps + ' · SCREEN ' + g.corvettes + '/9' +
+    '</div>'
+  ).join('') + (sel.length > 6 ? '<div class="sel-card">+' + (sel.length-6) + ' MORE</div>' : '');
+  refreshFleetStrip();
+  if (arco.some(a => !a.dead && !a.escaped)) refreshArcoStrip();
+}, 400);
+
+/* ── render ──────────────────────────────────────────────────────── */
+const stars = [];
+for (let i=0;i<240;i++) stars.push({ x: rnd()*WORLD.w, y: rnd()*WORLD.h, s: rnd()*1.4 + 0.3, a: rnd()*0.5 + 0.15 });
+
+function draw(){
+  ctx.clearRect(0, 0, vw, vh);
+  ctx.fillStyle = '#010508';
+  ctx.fillRect(0, 0, vw, vh);
+
+  ctx.save();
+  if (game.shake > 0.2){
+    ctx.translate((rnd()-0.5)*game.shake, (rnd()-0.5)*game.shake);
+  }
+  ctx.translate(vw/2, vh/2);
+  ctx.scale(cam.z, cam.z);
+  ctx.translate(-cam.x, -cam.y);
+
+  /* stars */
+  for (const s of stars){
+    ctx.globalAlpha = s.a;
+    ctx.fillStyle = '#cfe8f0';
+    ctx.fillRect(s.x, s.y, s.s/cam.z + 0.5, s.s/cam.z + 0.5);
+  }
+  ctx.globalAlpha = 1;
+
+  /* world bounds + grid */
+  ctx.strokeStyle = 'rgba(0,229,255,0.06)';
+  ctx.lineWidth = 1/cam.z;
+  for (let gx = 0; gx <= WORLD.w; gx += 400){
+    ctx.beginPath(); ctx.moveTo(gx, 0); ctx.lineTo(gx, WORLD.h); ctx.stroke();
+  }
+  for (let gy = 0; gy <= WORLD.h; gy += 400){
+    ctx.beginPath(); ctx.moveTo(0, gy); ctx.lineTo(WORLD.w, gy); ctx.stroke();
+  }
+  ctx.strokeStyle = 'rgba(0,229,255,0.18)';
+  ctx.strokeRect(0, 0, WORLD.w, WORLD.h);
+
+  /* interstice */
+  const it = performance.now()/1000;
+  ctx.save();
+  ctx.translate(INTERSTICE.x, INTERSTICE.y);
+  const grad = ctx.createRadialGradient(0, 0, 10, 0, 0, 220);
+  grad.addColorStop(0, 'rgba(150,200,255,0.25)');
+  grad.addColorStop(1, 'rgba(150,200,255,0)');
+  ctx.fillStyle = grad;
+  ctx.beginPath(); ctx.arc(0, 0, 220, 0, Math.PI*2); ctx.fill();
+  for (let ring = 0; ring < 3; ring++){
+    ctx.save();
+    ctx.rotate(it*0.15*(ring%2?1:-1) + ring);
+    ctx.strokeStyle = 'rgba(160,210,255,' + (0.5 - ring*0.13) + ')';
+    ctx.lineWidth = 2/cam.z;
+    ctx.beginPath();
+    const R = 90 + ring*34;
+    for (let i=0;i<=12;i++){
+      const a = i/12*Math.PI*2;
+      const px = Math.cos(a)*R, py = Math.sin(a)*R;
+      if (i===0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
+    }
+    ctx.stroke();
+    ctx.restore();
+  }
+  ctx.fillStyle = 'rgba(200,230,255,0.7)';
+  ctx.beginPath(); ctx.arc(0, 0, 26 + Math.sin(it*2)*4, 0, Math.PI*2); ctx.fill();
+  ctx.restore();
+
+  /* duster streams (only when submm radar is up) */
+  if (game.submm){
+    for (const d of dusts){
+      if (d.resolved || d.life <= 0) continue;
+      const L = 260;
+      const m = Math.hypot(d.vx, d.vy) || 1;
+      const ux = d.vx/m, uy = d.vy/m;
+      const gr = ctx.createLinearGradient(d.x - ux*L, d.y - uy*L, d.x, d.y);
+      gr.addColorStop(0, 'rgba(255,80,50,0)');
+      gr.addColorStop(1, 'rgba(255,110,70,0.85)');
+      ctx.strokeStyle = gr;
+      ctx.lineWidth = 5/cam.z;
+      ctx.beginPath(); ctx.moveTo(d.x - ux*L, d.y - uy*L); ctx.lineTo(d.x, d.y); ctx.stroke();
+    }
+  }
+
+  /* duster charge telegraph */
+  for (const a of arco){
+    if (a.dead || a.escaped || !a.dusterState) continue;
+    if (!game.submm) {
+      /* pre-unlock: only a faint nose glow, easy to miss — that's the point */
+      ctx.fillStyle = 'rgba(255,120,80,0.25)';
+      ctx.beginPath(); ctx.arc(a.x + Math.cos(a.angle)*a.radius*1.4, a.y + Math.sin(a.angle)*a.radius*1.4, 5, 0, Math.PI*2); ctx.fill();
+      continue;
+    }
+    const t = a.dusterState.target;
+    if (!t) continue;
+    ctx.save();
+    ctx.strokeStyle = 'rgba(255,80,50,' + (0.25 + 0.25*Math.sin(it*12)) + ')';
+    ctx.lineWidth = 1.5/cam.z;
+    ctx.setLineDash([14/cam.z, 10/cam.z]);
+    ctx.beginPath(); ctx.moveTo(a.x, a.y); ctx.lineTo(t.x, t.y); ctx.stroke();
+    ctx.restore();
+  }
+
+  /* torpedoes */
+  for (const t of torps){
+    if (t.dead) continue;
+    const m = Math.hypot(t.vx, t.vy) || 1;
+    ctx.strokeStyle = 'rgba(0,229,255,0.5)';
+    ctx.lineWidth = 1.6/cam.z;
+    ctx.beginPath(); ctx.moveTo(t.x - t.vx/m*16, t.y - t.vy/m*16); ctx.lineTo(t.x, t.y); ctx.stroke();
+    ctx.fillStyle = '#bff4ff';
+    ctx.fillRect(t.x-2, t.y-2, 4, 4);
+  }
+  /* railgun rounds */
+  for (const r of rounds){
+    if (r.dead) continue;
+    const m = Math.hypot(r.vx, r.vy) || 1;
+    ctx.strokeStyle = 'rgba(230,245,255,0.8)';
+    ctx.lineWidth = 1.4/cam.z;
+    ctx.beginPath(); ctx.moveTo(r.x - r.vx/m*22, r.y - r.vy/m*22); ctx.lineTo(r.x, r.y); ctx.stroke();
+  }
+  /* missiles */
+  for (const m of missiles){
+    if (m.dead) continue;
+    const s = Math.hypot(m.vx, m.vy) || 1;
+    ctx.strokeStyle = 'rgba(255,140,60,0.6)';
+    ctx.lineWidth = 1.6/cam.z;
+    ctx.beginPath(); ctx.moveTo(m.x - m.vx/s*20, m.y - m.vy/s*20); ctx.lineTo(m.x, m.y); ctx.stroke();
+    ctx.fillStyle = '#ffb060';
+    ctx.fillRect(m.x-2.4, m.y-2.4, 4.8, 4.8);
+  }
+
+  /* union groups */
+  for (const g of groups){
+    if (g.dead) continue;
+    const cold = g.playingDead || g.derelict;
+    /* corvette screen */
+    if (g.corvettes > 0){
+      ctx.fillStyle = cold ? 'rgba(110,140,150,0.5)' : 'rgba(0,229,255,0.75)';
+      for (let k=0;k<g.corvettes;k++){
+        const o = g.corvOff[k];
+        const a = o.a + it*0.4;
+        ctx.fillRect(g.x + Math.cos(a)*o.r - 1.5, g.y + Math.sin(a)*o.r - 1.5, 3, 3);
+      }
+    }
+    ctx.save();
+    ctx.translate(g.x, g.y);
+    ctx.rotate(g.derelict ? it*g.spin : g.angle);
+    /* drive plume */
+    const thrusting = !cold && (Math.hypot(g.vx,g.vy) > 16 || g.charging);
+    if (thrusting){
+      const pl = g.charging ? 46 : 22;
+      const gr = ctx.createLinearGradient(-g.radius, 0, -g.radius-pl, 0);
+      gr.addColorStop(0, g.charging ? 'rgba(255,200,120,0.95)' : 'rgba(120,220,255,0.8)');
+      gr.addColorStop(1, 'rgba(120,220,255,0)');
+      ctx.fillStyle = gr;
+      ctx.beginPath();
+      ctx.moveTo(-g.radius, -4); ctx.lineTo(-g.radius-pl, 0); ctx.lineTo(-g.radius, 4);
+      ctx.closePath(); ctx.fill();
+    }
+    /* hull: boxy tower */
+    ctx.fillStyle = g.flash > 0 ? '#fff'
+      : g.derelict ? '#3c4850'
+      : cold ? '#51646e'
+      : '#9adfd0';
+    ctx.fillRect(-12, -5, 24, 10);
+    ctx.fillRect(-5, -8, 10, 16);
+    if (!cold){
+      ctx.fillStyle = 'rgba(0,229,255,0.9)';
+      ctx.fillRect(8, -2, 4, 4);
+    }
+    ctx.restore();
+    /* selection + labels */
+    if (selected.has(g.id)){
+      ctx.strokeStyle = '#fff';
+      ctx.lineWidth = 1.2/cam.z;
+      const R = 24;
+      ctx.beginPath(); ctx.arc(g.x, g.y, R, 0, Math.PI*2); ctx.stroke();
+      if (g.dest){
+        ctx.strokeStyle = 'rgba(0,229,255,0.3)';
+        ctx.setLineDash([8/cam.z, 8/cam.z]);
+        ctx.beginPath(); ctx.moveTo(g.x, g.y); ctx.lineTo(g.dest.x, g.dest.y); ctx.stroke();
+        ctx.setLineDash([]);
+      }
+    }
+    if (cam.z > 0.18 && !g.derelict){
+      ctx.fillStyle = cold ? 'rgba(120,150,160,0.7)' : 'rgba(0,229,255,0.75)';
+      ctx.font = (10/cam.z) + 'px monospace';
+      ctx.textAlign = 'center';
+      ctx.fillText((g.id===10?'0':g.id) + (g.playingDead ? ' COLD' : ''), g.x, g.y - 26);
+    }
+    if (g.hp < g.maxHp && !g.derelict){
+      ctx.fillStyle = 'rgba(255,255,255,0.15)';
+      ctx.fillRect(g.x-16, g.y+20, 32, 3);
+      ctx.fillStyle = g.hp < 35 ? '#ff5040' : '#00e5ff';
+      ctx.fillRect(g.x-16, g.y+20, 32*g.hp/g.maxHp, 3);
+    }
+  }
+
+  /* arco ships */
+  for (const a of arco){
+    if (a.dead || a.escaped) continue;
+    ctx.save();
+    ctx.translate(a.x, a.y);
+    ctx.rotate(a.angle);
+    const sc = a.cls === 'incisor' ? 1 : 1.8;
+    /* antimatter plume */
+    if (Math.hypot(a.vx,a.vy) > 14){
+      const pl = 40*sc;
+      const gr = ctx.createLinearGradient(-14*sc, 0, -14*sc-pl, 0);
+      gr.addColorStop(0, 'rgba(255,255,255,0.95)');
+      gr.addColorStop(0.3, 'rgba(180,200,255,0.7)');
+      gr.addColorStop(1, 'rgba(180,200,255,0)');
+      ctx.fillStyle = gr;
+      ctx.beginPath();
+      ctx.moveTo(-14*sc, -3*sc); ctx.lineTo(-14*sc-pl, 0); ctx.lineTo(-14*sc, 3*sc);
+      ctx.closePath(); ctx.fill();
+    }
+    /* elongated pyramid dart */
+    ctx.fillStyle = a.flash > 0 ? '#fff' : '#e8543a';
+    ctx.beginPath();
+    ctx.moveTo(20*sc, 0);
+    ctx.lineTo(-13*sc, 8*sc);
+    ctx.lineTo(-8*sc, 0);
+    ctx.lineTo(-13*sc, -8*sc);
+    ctx.closePath(); ctx.fill();
+    /* spinal bore */
+    ctx.fillStyle = a.dusterState ? 'rgba(255,230,180,0.95)' : 'rgba(40,8,4,0.9)';
+    ctx.beginPath(); ctx.arc(13*sc, 0, 2.4*sc, 0, Math.PI*2); ctx.fill();
+    /* radiator strakes */
+    ctx.strokeStyle = 'rgba(255,235,220,0.85)';
+    ctx.lineWidth = 1.2;
+    ctx.beginPath(); ctx.moveTo(14*sc, 2.5*sc); ctx.lineTo(-9*sc, 6.5*sc); ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(14*sc, -2.5*sc); ctx.lineTo(-9*sc, -6.5*sc); ctx.stroke();
+    ctx.restore();
+    /* label + hp */
+    if (cam.z > 0.14){
+      ctx.fillStyle = 'rgba(255,107,53,0.85)';
+      ctx.font = (10/cam.z) + 'px monospace';
+      ctx.textAlign = 'center';
+      ctx.fillText(a.name, a.x, a.y - (a.cls==='incisor'?30:46));
+    }
+    if (a.hp < a.maxHp){
+      const w = a.cls === 'incisor' ? 36 : 56;
+      ctx.fillStyle = 'rgba(255,255,255,0.15)';
+      ctx.fillRect(a.x-w/2, a.y + (a.cls==='incisor'?26:40), w, 3);
+      ctx.fillStyle = '#ff6b35';
+      ctx.fillRect(a.x-w/2, a.y + (a.cls==='incisor'?26:40), w*a.hp/a.maxHp, 3);
+    }
+  }
+
+  /* beams */
+  for (const b of beams){
+    if (b.life <= 0) continue;
+    ctx.strokeStyle = b.color;
+    ctx.globalAlpha = Math.min(1, b.life*8);
+    ctx.lineWidth = b.w/cam.z;
+    ctx.beginPath(); ctx.moveTo(b.x1, b.y1); ctx.lineTo(b.x2, b.y2); ctx.stroke();
+    ctx.globalAlpha = 1;
+  }
+
+  /* fx */
+  for (const f of fx){
+    const p = f.t/f.dur;
+    if (p >= 1) continue;
+    if (f.type === 'boom' || f.type === 'ring' || f.type === 'gamma'){
+      ctx.globalAlpha = 1 - p;
+      ctx.strokeStyle = f.color;
+      ctx.lineWidth = (f.type === 'gamma' ? 3 : 2)/cam.z;
+      ctx.beginPath(); ctx.arc(f.x, f.y, f.maxR*p, 0, Math.PI*2); ctx.stroke();
+      if (f.type === 'boom' && p < 0.4){
+        ctx.fillStyle = f.color;
+        ctx.globalAlpha = (1 - p/0.4)*0.9;
+        ctx.beginPath(); ctx.arc(f.x, f.y, f.maxR*0.3*(1-p), 0, Math.PI*2); ctx.fill();
+      }
+      ctx.globalAlpha = 1;
+    } else if (f.type === 'spark'){
+      ctx.globalAlpha = 1 - p;
+      ctx.fillStyle = f.color;
+      ctx.fillRect(f.x + f.vx*f.t - 1.5, f.y + f.vy*f.t - 1.5, 3, 3);
+      ctx.globalAlpha = 1;
+    }
+  }
+
+  /* selection box */
+  ctx.restore();
+  if (dragStart && dragNow && Math.hypot(dragNow.x-dragStart.x, dragNow.y-dragStart.y) > 7){
+    ctx.strokeStyle = 'rgba(0,229,255,0.7)';
+    ctx.fillStyle = 'rgba(0,229,255,0.06)';
+    ctx.lineWidth = 1;
+    const x = Math.min(dragStart.x, dragNow.x), y = Math.min(dragStart.y, dragNow.y);
+    const w = Math.abs(dragNow.x-dragStart.x), h = Math.abs(dragNow.y-dragStart.y);
+    ctx.fillRect(x, y, w, h);
+    ctx.strokeRect(x, y, w, h);
+  }
+}
+
+/* ── main loop ───────────────────────────────────────────────────── */
+let scheduleIdx = 0;
+function update(dt){
+  game.t += dt;
+  game.shake = Math.max(0, game.shake - dt*14);
+
+  while (scheduleIdx < schedule.length && schedule[scheduleIdx].t <= game.t){
+    schedule[scheduleIdx].fn();
+    scheduleIdx++;
+  }
+  if (game.analyse === 2){
+    game.analyseT -= dt;
+    const btn = document.getElementById('analyse-btn');
+    btn.textContent = 'ANALYSING… ' + Math.ceil(game.analyseT) + 's';
+    if (game.analyseT <= 0) finishAnalyse();
+  }
+
+  for (const g of groups) updateGroup(g, dt);
+  for (const a of arco) updateArco(a, dt);
+  updateProjectiles(dt);
+
+  /* prune dead projectiles/fx */
+  for (let i=torps.length-1;i>=0;i--) if (torps[i].dead) torps.splice(i,1);
+  for (let i=rounds.length-1;i>=0;i--) if (rounds[i].dead || rounds[i].life<=0) rounds.splice(i,1);
+  for (let i=missiles.length-1;i>=0;i--) if (missiles[i].dead) missiles.splice(i,1);
+  for (let i=dusts.length-1;i>=0;i--) if (dusts[i].life <= -1) dusts.splice(i,1);
+  for (let i=beams.length-1;i>=0;i--) if (beams[i].life <= 0) beams.splice(i,1);
+  for (let i=fx.length-1;i>=0;i--) if (fx[i].t >= fx[i].dur) fx.splice(i,1);
+
+  checkEnd(dt);
+
+  const m = Math.floor(game.t/60), s = Math.floor(game.t%60);
+  document.getElementById('clock').textContent = 'T+' + String(m).padStart(2,'0') + ':' + String(s).padStart(2,'0');
+}
+
+let last = 0;
+function loop(now){
+  requestAnimationFrame(loop);
+  const dt = Math.min((now - last)/1000, 0.05) * game.speed;
+  last = now;
+  if (game.running && !game.paused && !game.over) update(dt);
+  draw();
+}
+
+/* ── ui wiring ───────────────────────────────────────────────────── */
+function togglePause(){
+  if (!game.running || game.over) return;
+  game.paused = !game.paused;
+  document.getElementById('btn-pause').textContent = game.paused ? 'RESUME' : 'PAUSE';
+  document.getElementById('btn-pause').classList.toggle('armed', game.paused);
+}
+document.getElementById('btn-pause').addEventListener('click', togglePause);
+document.getElementById('btn-speed').addEventListener('click', function(){
+  game.speed = game.speed === 1 ? 2 : 1;
+  this.textContent = game.speed + '×';
+});
+document.getElementById('btn-fit').addEventListener('click', fitCamera);
+document.getElementById('btn-all').addEventListener('click', selectAll);
+document.getElementById('btn-volley').addEventListener('click', () => setMode(mode === 'volley' ? null : 'volley'));
+document.getElementById('btn-charge').addEventListener('click', () => setMode(mode === 'charge' ? null : 'charge'));
+document.getElementById('btn-dead').addEventListener('click', togglePlayDead);
+document.getElementById('analyse-btn').addEventListener('click', startAnalyse);
+document.getElementById('btn-help').addEventListener('click', () => {
+  document.getElementById('helpov').style.display = 'flex';
+  game.paused = true;
+  document.getElementById('btn-pause').textContent = 'RESUME';
+});
+document.getElementById('btn-helpclose').addEventListener('click', () => {
+  document.getElementById('helpov').style.display = 'none';
+  game.paused = false;
+  document.getElementById('btn-pause').textContent = 'PAUSE';
+});
+document.getElementById('btn-start').addEventListener('click', () => {
+  document.getElementById('briefing').style.display = 'none';
+  game.running = true;
+  log('First Fleet on station. Ten battlegroups, ninety corvettes, a hundred thousand kilometres of cordon.');
+});
+document.getElementById('btn-restart').addEventListener('click', () => location.reload());
+
+/* ── boot ────────────────────────────────────────────────────────── */
+initGame();
+resize();
+fitCamera();
+refreshFleetStrip();
+refreshArcoStrip();
+requestAnimationFrame(loop);
+
+/* test hooks (harmless in production) */
+window.__threshold = { game, groups, arco, torps, update, draw, fireVolley, orderCharge, selectAll, stats };
+
+})();
+</script>
+<script src="nav.js"></script>
+</body>
+</html>


### PR DESCRIPTION
…hold

Real-time strategy game in a single self-contained page (canvas 2D, no dependencies). Player commands all ten Union destroyer battlegroups with corvette screens (100 ships, per canon) against three Incisors and an Annihilator emerging from the interstice in 2909 CE.

Canon mechanics from the Eszel prologue:
- X-ray lasers intercept torpedoes at range; only massed close volleys saturate the defence
- Invisible duster fire kills ships "with no apparent cause" until the player analyses sensor logs and unlocks submillimetre radar
- Striver malware fires an uncommanded opening volley; weapons hold until Arco engages
- Play dead + 30G suicide charge: the Isidore gambit, launched from cold for total surprise; the crew does not survive
- Incisors stand off, dodge railgun rounds, dive through the formation, break off when wounded; Annihilator launches antimatter missile swarms
- Aftermath graded against the historical record (97/100 lost, one kill)

Balance verified by headless Node simulation: passive play is annihilated with zero kills, naive aggression matches history, coordinated tactics are decisively rewarded.

Wired into nav.js, simulations hub (new PLAYABLE section), home page card grid, README, and CHANGELOG.

https://claude.ai/code/session_01KNcBtw3S71zTmUKzwAcoNA